### PR TITLE
Trying to fix site name problems in Google

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,13 +4,12 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta name="description" content="Kartalla - Osallistava kyselypalvelu" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Karttakysely</title>
+    <title>Kartalla</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "name": "Kartalla - osallistava kyselypalvelu",
-        "alternateName": ["Kartalla", "kartalla", "kartalla.io"],
+        "name": "kartalla.io",
         "url": "https://kartalla.io/"
       }
     </script>


### PR DESCRIPTION
Tried the "last resort" option of only defining the host name as the site name, hopefully it will now appear as the site name in Google search results...

https://developers.google.com/search/docs/appearance/site-names#troubleshooting