### PR TITLE
Import the encryption key via environment variables

### DIFF
--- a/server/migrations/1736504593192_encrypt-users.ts
+++ b/server/migrations/1736504593192_encrypt-users.ts
@@ -1,8 +1,11 @@
 import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
-import { encryptionKey } from './../src/database';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
+const encryptionKey = process.env.DATABASE_ENCRYPTION_KEY;
+if (!encryptionKey) {
+  throw new Error(`Environment variable DATABASE_ENCRYPTION_KEY is missing!`);
+}
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(`


### PR DESCRIPTION
This PR fixes the bug in importing the encryption key in the production environment.