### PR TITLE
Fix answer view map and survey follow up section deletion bug

### DIFF
--- a/client/src/components/admin/AdminMap.tsx
+++ b/client/src/components/admin/AdminMap.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export function AdminMap({ url, page, allowDrawing = false }: Props) {
-  const iframeRef = useRef<HTMLIFrameElement>();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const {
     setRpcChannel,
     isMapReady,

--- a/client/src/components/admin/SubmissionsPage/AnswerMap.tsx
+++ b/client/src/components/admin/SubmissionsPage/AnswerMap.tsx
@@ -143,14 +143,21 @@ export default function AnswerMap({
     if (!survey || !selectedQuestion) {
       return [];
     }
-    const mapQuestion = questions.find((question) => question.type === 'map');
-    if (!mapQuestion) return [];
+
+    const firstQuestionWithMap = questions.find(
+      (question) =>
+        question.type === 'map' ||
+        question.followUpSections?.some((section) => section.type === 'map'),
+    );
+    if (!firstQuestionWithMap) return [];
     // If all answers are currently shown, find the first map question to determine shown map layers
     const page = survey.pages.find((page) =>
       page.sections.some(
         (section) =>
           section.id ===
-          (selectedQuestion.id === 0 ? mapQuestion.id : selectedQuestion.id),
+          (selectedQuestion.id === 0
+            ? firstQuestionWithMap.id
+            : selectedQuestion.id),
       ),
     );
     return page.sidebar.mapLayers;

--- a/client/src/components/admin/SurveyListItem.tsx
+++ b/client/src/components/admin/SurveyListItem.tsx
@@ -11,7 +11,6 @@ import {
   Theme,
   Typography,
 } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import CalendarSmallIcon from '@src/components/icons/CalendarSmallIcon';
 import LinkSmallIcon from '@src/components/icons/LinkSmallIcon';
 import UserSmallIcon from '@src/components/icons/UserSmallIcon';
@@ -23,15 +22,16 @@ import {
 import { useToasts } from '@src/stores/ToastContext';
 import { useTranslations } from '@src/stores/TranslationContext';
 import { useUser } from '@src/stores/UserContext';
-import clsx from 'clsx';
+
 import { format } from 'date-fns';
 import React, { useMemo, useState } from 'react';
 import { NavLink, useRouteMatch } from 'react-router-dom';
 import ConfirmDialog from '../ConfirmDialog';
 import CopyToClipboard from '../CopyToClipboard';
 import LoadingButton from '../LoadingButton';
+import { theme } from '@src/themes/admin';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const cardStyles = (theme: Theme, loading: boolean, published: boolean) => ({
   '@keyframes pulse': {
     '0%': {
       opacity: 0.4,
@@ -43,20 +43,16 @@ const useStyles = makeStyles((theme: Theme) => ({
       opacity: 0.4,
     },
   },
-  loading: {
-    animation: `$pulse 1s ${theme.transitions.easing.easeIn} infinite`,
+  ...(loading && {
+    animation: `pulse 2s ${theme.transitions.easing.easeIn} infinite`,
     pointerEvents: 'none',
     filter: 'grayscale(100%)',
-  },
-  cardRoot: {
-    paddingBottom: '8px',
-  },
-  publishedCard: {
+  }),
+  ...(published && {
     borderLeft: 'solid 5px',
     borderLeftColor: theme.palette.primary.main,
-  },
-}));
-
+  }),
+});
 interface Props {
   survey: Survey;
 }
@@ -69,7 +65,6 @@ export default function SurveyListItem(props: Props) {
     useState(false);
   const [loading, setLoading] = useState(false);
 
-  const classes = useStyles();
   const { tr, surveyLanguage } = useTranslations();
   const { showToast } = useToasts();
   const { url } = useRouteMatch();
@@ -104,13 +99,8 @@ export default function SurveyListItem(props: Props) {
 
   return (
     <li style={{ marginBottom: '20px' }}>
-      <Card
-        className={clsx(
-          loading && classes.loading,
-          survey.isPublished && classes.publishedCard,
-        )}
-      >
-        <CardContent classes={{ root: classes.cardRoot }}>
+      <Card sx={cardStyles(theme, loading, survey.isPublished)}>
+        <CardContent sx={{ paddingBottom: '8px' }}>
           <Typography variant="h6" component="h3">
             {!survey.title?.[surveyLanguage] ? (
               <em>{tr.SurveyList.untitledSurvey}</em>

--- a/client/src/components/admin/SurveySectionAccordion/FollowUpSectionMenu.tsx
+++ b/client/src/components/admin/SurveySectionAccordion/FollowUpSectionMenu.tsx
@@ -58,6 +58,7 @@ export function FollowUpSectionMenu({
       slider: 'sliderQuestion',
       sorting: 'sortingQuestion',
       text: 'textSection',
+      'personal-info': 'personalInfoQuestion',
     };
 
     if (!Object.keys(translationEntries).includes(type))

--- a/server/src/application/survey.ts
+++ b/server/src/application/survey.ts
@@ -1099,9 +1099,13 @@ async function deleteRemovedLinkedSections(
   newSubQuestions: SurveyMapSubQuestion[],
   newFollowUpSections: SurveyPageSection[],
 ) {
-  // Get all existing sections
+  // Get all existing linked sections (follow-up sections can have child sections but child sections can't have follow-up sections)
   const rows = await getDb().manyOrNone<{ id: number }>(
-    `SELECT id FROM data.page_section WHERE predecessor_section = $1 OR parent_section = $1`,
+    `WITH follow_ups AS 
+      (SELECT id FROM DATA.page_section WHERE predecessor_section = $1), 
+    child_sections AS 
+      (SELECT ps.id FROM DATA.page_section ps INNER JOIN follow_ups ON ps.parent_section = follow_ups.id) 
+    SELECT id FROM follow_ups UNION SELECT id FROM child_sections;`,
     [parentSectionId],
   );
 


### PR DESCRIPTION
- Fix a bug where submissions page map wouldn't display when there was only follow-up map questions 
  - Survey map will not be displayed if there's no map questions even if the map is provided in the survey
- Fixed follow-up section deletion bug causing follow-up section (for example map question) child section to remain undeleted when its parent was deleted
  - This also prevented access to survey editing and survey submissions view      