### PR TITLE
Fix/map layer name and icon size fixes

### DIFF
--- a/server/src/application/map.ts
+++ b/server/src/application/map.ts
@@ -18,22 +18,25 @@ export async function getAvailableMapLayers(
       configuration: {
         mapfull: {
           conf: {
-            layers: MapLayer[];
+            layers: {
+              id: number;
+              name?: string;
+              locale?: Record<
+                'fi' | 'en' | 'sv',
+                {
+                  name?: string;
+                }
+              >;
+            }[];
           };
         };
       };
     };
     const layers = responseJson.configuration?.mapfull?.conf?.layers?.map(
-      ({ id, name }) => ({
+      ({ id, name, locale }) => ({
         id,
-        name:
-          typeof name === 'string'
-            ? name
-            : // For user-created datasets, the name might be a localized object instead of a string.
-              // In this case, just pick the first one available
-              Object.keys(name).length > 0
-              ? name[Object.keys(name)[0]]
-              : '<untitled layer>',
+        // For user-created datasets, the name is inside the locale object
+        name: locale?.fi?.name ?? name ?? '<untitled layer>',
       }),
     );
     // For non-existent UUIDs the full layer path won't exist in the response object

--- a/server/src/application/screenshot.ts
+++ b/server/src/application/screenshot.ts
@@ -8,7 +8,6 @@ import parseCSSColor from 'parse-css-color';
 import { Page } from 'puppeteer';
 import { Cluster } from 'puppeteer-cluster';
 import { getAvailableMapLayers } from './map';
-import logger from '@src/logger';
 
 /**
  * Oskari needs to be declared, because it is available as a global variable inside
@@ -147,7 +146,7 @@ async function generateScreenshots({
               shape: question.featureStyles?.point?.markerIcon ?? 0,
               offsetX: 0,
               offsetY: 0,
-              size: question.featureStyles?.point?.markerIcon ? 64 : 12,
+              size: question.featureStyles?.point?.markerIcon ? 128 : 12,
             },
           ]);
           sandbox.postRequestByName('MapMoveRequest', [


### PR DESCRIPTION
- Get Oskari layer name primarily from `locale` object that contains the real name, but only for user-created datasets (otherwise keep using `name`)
- Made the custom icon size bigger for PDF report screenshots (scaling had changed in some Oskari update)