### PR TITLE
Fix budgeting question bug preventing survey submission

### DIFF
--- a/client/src/components/admin/EditBudgetingQuestion.tsx
+++ b/client/src/components/admin/EditBudgetingQuestion.tsx
@@ -31,12 +31,16 @@ export default function EditBudgetingQuestion({ section, onChange }: Props) {
         control={
           <Switch
             checked={section.budgetingMode === 'pieces'}
-            onChange={(event) =>
+            onChange={(event) => {
+              const budgetingMode = event.target.checked ? 'pieces' : 'direct';
               onChange({
                 ...section,
-                budgetingMode: event.target.checked ? 'pieces' : 'direct',
-              })
-            }
+                budgetingMode,
+                ...(budgetingMode === 'pieces' && {
+                  requireFullAllocation: false,
+                }),
+              });
+            }}
           />
         }
       />


### PR DESCRIPTION
- If budgeting mode was set to 'pieces' after checking 'require full allocation' then a partially allocated answer couldn't be submitted